### PR TITLE
Add RemoteProxy::getMethods-method to provide for basic "introspection" what methods can be called

### DIFF
--- a/src/DNode/RemoteProxy.php
+++ b/src/DNode/RemoteProxy.php
@@ -5,6 +5,11 @@ class RemoteProxy
 {
     private $methods = array();
 
+    public function getMethods() 
+    {
+      return $this->methods;
+    }
+
     public function setMethod($method, $closure)
     {
         $this->methods[$method] = $closure;


### PR DESCRIPTION
First of all, thanks a lot for coding this library! As I am working on some drupal-nodejs integration via dnode (http://drupal.org/sandbox/frega/1321342), it would be great to have basic access to what methods can be called remotely. 

The (very basic) pull-request provides a simple accessor method. Am not sure how dnode (or other client libraries) handle this, but perhaps this is useful. 

Again, thanks a lot for coding this :) best, fredrik
