### PR TITLE
Set DNode handleConnection to protected rather than private.

### DIFF
--- a/src/DNode/DNode.php
+++ b/src/DNode/DNode.php
@@ -57,7 +57,7 @@ class DNode extends EventEmitter
         }
     }
 
-    private function handleConnection($stream, $params)
+    protected function handleConnection($stream, $params)
     {
         $client = $this->protocol->create();
         foreach ($this->stack as $middleware) {


### PR DESCRIPTION
In order to allow child classes of DNode to call handleConnection the method needs to be protected rather than private. I would like this in order to e.g. provide application specific connect() methods. 
