### PR TITLE
Fixed preg_match usage in Protocol.php

### DIFF
--- a/src/DNode/Protocol.php
+++ b/src/DNode/Protocol.php
@@ -36,11 +36,11 @@ class Protocol
 
         foreach ($args as $arg) {
             if (is_string($arg)) {
-                if (preg_match('/^\d+$/')) {
+                if (preg_match('/^\d+$/', $arg)) {
                     $params['port'] = $arg;
                     continue;
                 }
-                if (preg_match('^/')) {
+                if (preg_match('/^\\//', $arg)) {
                     $params['path'] = $arg;
                     continue;
                 }


### PR DESCRIPTION
This removes persistent php warnings when DNode\DNode is created with arbitrary parameters.
