### PR TITLE
Correctly handle TCP fragmentation

### DIFF
--- a/src/DNode/DNode.php
+++ b/src/DNode/DNode.php
@@ -93,15 +93,14 @@ class DNode extends EventEmitter
 
             $conn->dNodeBuffer .= $data;
             if (false !== strpos($conn->dNodeBuffer, "\n")) {
-                // We got a full command, run it
                 $commands = explode("\n", $conn->dNodeBuffer);
+                $tail = array_pop($commands);
+
                 foreach ($commands as $command) {
-                    if (empty($command)) {
-                        continue;
-                    }
                     $client->parse($command);
                 }
-                $conn->dNodeBuffer = '';
+
+                $conn->dNodeBuffer = $tail;
             }
         });
 


### PR DESCRIPTION
If full message was received, tail will be an empty string. If partial
message was received, tail will contain the rest of the next message.
