### PR TITLE
Alternate Scheme Support for Client

### DIFF
--- a/src/DNode/Connection.php
+++ b/src/DNode/Connection.php
@@ -1,0 +1,33 @@
+<?php
+namespace DNode;
+use React\EventLoop\LoopInterface;
+use React\Socket\Connection as BaseConnection;
+
+class Connection extends BaseConnection
+{
+    private $streamReadFunctionName = 'fread';
+
+    private static $rawIoSchemes = array(
+        'tcp',
+        'udp'
+    );
+
+    public function __construct($stream, LoopInterface $loop, $scheme)
+    {
+        parent::__construct($stream, $loop);
+        if (in_array($scheme, static::$rawIoSchemes)) {
+            $this->streamReadFunctionName = 'stream_socket_recvfrom';
+        }
+    }
+
+    public function handleData($stream)
+    {
+        $data = call_user_func_array($this->streamReadFunctionName, array($stream, $this->bufferSize));
+
+        if ('' === $data || false === $data) {
+            $this->end();
+        } else {
+            $this->emit('data', array($data, $this));
+        }
+    }
+}

--- a/src/DNode/DNode.php
+++ b/src/DNode/DNode.php
@@ -3,7 +3,6 @@ namespace DNode;
 use Evenement\EventEmitter;
 use React\EventLoop\LoopInterface;
 use React\Socket\Server;
-use React\Socket\Connection;
 use React\Socket\ConnectionInterface;
 
 class DNode extends EventEmitter
@@ -30,17 +29,25 @@ class DNode extends EventEmitter
     public function connect()
     {
         $params = $this->protocol->parseArgs(func_get_args());
+
+        if (!isset($params['scheme'])) {
+            $params['scheme'] = 'tcp:';
+        }
+
         if (!isset($params['host'])) {
             $params['host'] = '127.0.0.1';
         }
 
         if (!isset($params['port'])) {
-            throw new \Exception("For now we only support TCP connections to a defined port");
+            throw new \Exception("For now we only support connections to a defined port");
         }
 
-        $client = @stream_socket_client("tcp://{$params['host']}:{$params['port']}");
+        $url = "{$params['scheme']}//{$params['host']}:{$params['port']}";
+        $client = @stream_socket_client($url);
+
         if (!$client) {
-            $e = new \RuntimeException("No connection to DNode server in tcp://{$params['host']}:{$params['port']}");
+            $e = new \RuntimeException("No connection to DNode server in $url");
+
             $this->emit('error', array($e));
 
             if (!count($this->listeners('error'))) {
@@ -50,7 +57,7 @@ class DNode extends EventEmitter
             return;
         }
 
-        $conn = new Connection($client, $this->loop);
+        $conn = new Connection($client, $this->loop, $params['scheme']);
         $this->handleConnection($conn, $params);
     }
 

--- a/src/DNode/DNode.php
+++ b/src/DNode/DNode.php
@@ -31,7 +31,7 @@ class DNode extends EventEmitter
         $params = $this->protocol->parseArgs(func_get_args());
 
         if (!isset($params['scheme'])) {
-            $params['scheme'] = 'tcp:';
+            $params['scheme'] = 'tcp';
         }
 
         if (!isset($params['host'])) {
@@ -42,7 +42,7 @@ class DNode extends EventEmitter
             throw new \Exception("For now we only support connections to a defined port");
         }
 
-        $url = "{$params['scheme']}//{$params['host']}:{$params['port']}";
+        $url = "{$params['scheme']}://{$params['host']}:{$params['port']}";
         $client = @stream_socket_client($url);
 
         if (!$client) {
@@ -57,7 +57,7 @@ class DNode extends EventEmitter
             return;
         }
 
-        $conn = new Connection($client, $this->loop, $params['scheme']);
+        $conn = new Connection($client, $this->loop);
         $this->handleConnection($conn, $params);
     }
 

--- a/src/DNode/DNode.php
+++ b/src/DNode/DNode.php
@@ -42,6 +42,12 @@ class DNode extends EventEmitter
             throw new \Exception("For now we only support connections to a defined port");
         }
 
+        if (!in_array($params['scheme'], stream_get_transports())) {
+            $e = new \InvalidArgumentException("Scheme {$params['scheme']} is not supported... are you missing an extension?");
+
+            $this->emit('error', array($e));
+        }
+
         $url = "{$params['scheme']}://{$params['host']}:{$params['port']}";
         $client = @stream_socket_client($url);
 

--- a/src/DNode/Protocol.php
+++ b/src/DNode/Protocol.php
@@ -53,10 +53,6 @@ class Protocol
                     $params['path'] = $arg;
                     continue;
                 }
-                if (preg_match('/\w+:$/', $arg)) {
-                    $params['scheme'] = $arg;
-                    continue;
-                }
                 $params['host'] = $arg;
                 continue;
             }
@@ -77,9 +73,11 @@ class Protocol
                     continue;
                 }
 
-                foreach ($arg as $key => $value) {
-                    $params[$key] = $value;
-                }
+                $arg = (array) $arg;
+            }
+
+            if (is_array($arg)) {
+                $params = array_merge($params, $arg);
                 continue;
             }
 

--- a/src/DNode/Protocol.php
+++ b/src/DNode/Protocol.php
@@ -53,6 +53,10 @@ class Protocol
                     $params['path'] = $arg;
                     continue;
                 }
+                if (preg_match('/\w+:$/', $arg)) {
+                    $params['scheme'] = $arg;
+                    continue;
+                }
                 $params['host'] = $arg;
                 continue;
             }

--- a/tests/DNode/ProtocolTest.php
+++ b/tests/DNode/ProtocolTest.php
@@ -66,6 +66,11 @@ class ProtocolTest extends TestCase
         $obj->foo = 'bar';
         $obj->baz = 'qux';
 
+        $arr = array(
+            'quux' => 'corge',
+            'grault' => 'garply'
+        );
+
         return array(
             'string number becomes port' => array(
                 array('port' => '8080'),
@@ -82,6 +87,10 @@ class ProtocolTest extends TestCase
             'integer becomes port' => array(
                 array('port' => 8080),
                 array(8080),
+            ),
+            'array becomes merged' => array(
+                array('quux' => 'corge', 'grault' => 'garply'),
+                array($arr),
             ),
             'Closure becomes block' => array(
                 array('block' => $closure),
@@ -102,11 +111,11 @@ class ProtocolTest extends TestCase
      * @test
      * @covers DNode\Protocol::parseArgs
      * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Not sure what to do about array arguments
+     * @expectedExceptionMessage Not sure what to do about boolean arguments
      */
     public function parseArgsShouldRejectInvalidArgs()
     {
-        $args = array(array('wat'));
+        $args = array(true);
         $this->protocol->parseArgs($args);
     }
 }


### PR DESCRIPTION
I wanted to use the client with SSL and found DNode very difficult to extend so I added the support directly.  The parsing of the scheme argument to the connect method is a bit odd, but was need to maintain compatibility with existing calls.

The new Connection class is simply to perform buffered IO on the stream as required by various wrapper streams, but leave the raw IO enabled for UDP (and TCP just to change as little as possible).

The use case for these changes is to have a client connect over SSL to a server wrapped with stunnel.  Cheers.
