### PR TITLE
Modified wrapper reflection to skip enumerating constructor.

### DIFF
--- a/src/DNode/Session.php
+++ b/src/DNode/Session.php
@@ -133,7 +133,7 @@ class Session extends EventEmitter
                 $reflector = new \ReflectionClass($node);
                 $methods = $reflector->getMethods();
                 foreach ($methods as $method) {
-                    if (!$method->isPublic() || $method->isConstructor()) {
+                    if (!$method->isPublic() || $method->isConstructor() || $method->isDestructor()) {
                         continue;
                     }
 

--- a/src/DNode/Session.php
+++ b/src/DNode/Session.php
@@ -133,7 +133,7 @@ class Session extends EventEmitter
                 $reflector = new \ReflectionClass($node);
                 $methods = $reflector->getMethods();
                 foreach ($methods as $method) {
-                    if (!$method->isPublic()) {
+                    if (!$method->isPublic() || $method->isConstructor()) {
                         continue;
                     }
 

--- a/tests/DNode/Dog.php
+++ b/tests/DNode/Dog.php
@@ -3,6 +3,11 @@ namespace DNode;
 
 class Dog
 {
+    public function __construct()
+    {
+
+    }
+
     public function bark()
     {
     }

--- a/tests/DNode/Dog.php
+++ b/tests/DNode/Dog.php
@@ -5,7 +5,10 @@ class Dog
 {
     public function __construct()
     {
+    }
 
+    public function __destruct()
+    {
     }
 
     public function bark()


### PR DESCRIPTION
I modified the wrapper reflection in `Session::scrub` to not enumerate the constructor on objects.  While there is generally no harm in the constructor being enumerated or even invoked, it does not make sense.

I added a constructor to the `Dog` test class to verify the enumeration was skipping the constructor.  All tests are passing.
