### PR TITLE
Support react 0.4 and evenement 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "evenement/evenement": "~1.0",
-        "react/socket": "0.3.*"
+        "evenement/evenement": ">=1.0",
+        "react/socket": ">=0.3.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
A project I'm working on uses react 0.4  everywhere. [Adding DNode](https://github.com/WyriHaximus/RatchetCommands/issues/7) support is next on the list but the current composer.json blocks that. This proposed change lets users  use either 0.3 or 0.4.
